### PR TITLE
Bug Fix: Allow running without a 'gated_fcs_dir'

### DIFF
--- a/cytof_pipeline.R
+++ b/cytof_pipeline.R
@@ -561,14 +561,13 @@ if( dir.exists(gated_fcs_dir) ) {
     }
     write.FCS(tmp_fcs, paste0(scaffold_dir, "/gated/", basename(gf_file)))
   }
-  
-  if(is.null(make_scaffold_map)) {
-    if( length(gated_fcss) > 0 ) {
-      make_scaffold_map <- TRUE
-    } else {
-      make_scaffold_map <- FALSE
-      print_message("No gated FCS files were provided. SCAFFoLD map generation will be skipped.")
-    }
+}
+if(is.null(make_scaffold_map)) {
+  if( exists(gated_fcss) && length(gated_fcss) > 0 ) {
+    make_scaffold_map <- TRUE
+  } else {
+    make_scaffold_map <- FALSE
+    print_message("No gated FCS files were provided. SCAFFoLD map generation will be skipped.")
   }
 }
 ############# END: Set up SCAFFoLD analysis directories ################

--- a/cytof_pipeline.R
+++ b/cytof_pipeline.R
@@ -563,7 +563,7 @@ if( dir.exists(gated_fcs_dir) ) {
   }
 }
 if(is.null(make_scaffold_map)) {
-  if( exists(gated_fcss) && length(gated_fcss) > 0 ) {
+  if( exists("gated_fcss") && length(gated_fcss) > 0 ) {
     make_scaffold_map <- TRUE
   } else {
     make_scaffold_map <- FALSE


### PR DESCRIPTION
I think a recent update introduced a bug where the config file's 'gated_fcs_dir' must be a real directory or else the pipeline errors out in step 6.

### The bug:
A cyclone run where the config file 'gated_fcs_dir' is not a real directory (because I don't have gated fcs files to power SCAFFoLD analysis; derp value I filled it in with was "/boop/boop/boop") fails after completing step 5 with this at the end of the log file.
```
##########################################################
Starting step#: 5
[ 2023-01-03 07:18:29 ] Checkpoint #5 reached. Saving the newly generated data. 
[ 2023-01-03 07:18:30 ] Data is saved in /krummellab/data1/DSCoLab/XNEO1/cytof/All_runs_1_to_10/processed/clustering_pipeline_subsample_with_control/checkpoint_5.RData 



##########################################################
Starting step#: 6
Error in if (make_scaffold_map) { : argument is of length zero
Execution halted
```

### Fix here:
This PR adjusts the logic around setting the 'make_scaffold_map' logical value in order to ensure it still gets set.